### PR TITLE
Handle failed NFS response for zero copy reads

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -896,6 +896,15 @@ rpc_read_from_socket(struct rpc_context *rpc)
                                 /* We do not have rpc->pdu for server context */
                                 if (rpc->pdu && rpc->pdu->free_zdr) {
                                         /*
+                                         * If the READ failed, bail out here as there is no
+                                         * data.
+                                         */
+                                        const READ3res *res = (READ3res *) rpc->pdu->zdr_decode_buf;
+                                        if (res->status != NFS3_OK) {
+                                                goto payload_finished;
+                                        }
+
+                                        /*
                                          * We are doing zero-copy read.
                                          * pdu->read_count is the amount of read data returned by
                                          * the server in this RPC response.
@@ -950,9 +959,7 @@ rpc_read_from_socket(struct rpc_context *rpc)
                                                 continue;
                                         }
                                 }
-#ifdef HAVE_LIBKRB5
                         payload_finished:
-#endif /* HAVE_LIBKRB5 */
                                 if (rpc->fragments) {
                                         free(rpc->buf);
                                         rpc->buf = NULL;


### PR DESCRIPTION
Currently we go ahead and try to read the data which causes it to fail and initiates a reconnect. Caller never gets a response for such failed READ pdus.