### PR TITLE
Add non-IO RPC PDUs to head of outqueue

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -615,6 +615,7 @@ struct rpc_pdu {
 
 void rpc_reset_queue(struct rpc_queue *q);
 void rpc_enqueue(struct rpc_queue *q, struct rpc_pdu *pdu);
+void rpc_add_to_outqueue(struct rpc_context *rpc, struct rpc_pdu *pdu);
 void rpc_return_to_outqueue(struct rpc_context *rpc, struct rpc_pdu *pdu);
 int rpc_remove_pdu_from_queue(struct rpc_queue *q, struct rpc_pdu *remove_pdu);
 unsigned int rpc_hash_xid(struct rpc_context *rpc, uint32_t xid);
@@ -624,6 +625,7 @@ void pdu_set_timeout(struct rpc_context *rpc, struct rpc_pdu *pdu, uint64_t now_
 
 void rpc_free_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu);
 int rpc_queue_pdu(struct rpc_context *rpc, struct rpc_pdu *pdu);
+int rpc_queue_pdu2(struct rpc_context *rpc, struct rpc_pdu *pdu, bool_t high_prio);
 int rpc_process_pdu(struct rpc_context *rpc, char *buf, int size);
 struct rpc_pdu *rpc_find_pdu(struct rpc_context *rpc, uint32_t xid);
 void rpc_error_all_pdus(struct rpc_context *rpc, const char *error);

--- a/nfs/nfs.c
+++ b/nfs/nfs.c
@@ -123,7 +123,7 @@ struct rpc_pdu *rpc_nfs3_null_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/NULL call");
 		return NULL;
 	}
@@ -149,7 +149,7 @@ struct rpc_pdu *rpc_nfs3_getattr_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/GETATTR call");
 		return NULL;
 	}
@@ -175,7 +175,7 @@ struct rpc_pdu *rpc_nfs3_pathconf_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/PATHCONF call");
 		return NULL;
 	}
@@ -201,7 +201,7 @@ struct rpc_pdu *rpc_nfs3_lookup_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/LOOKUP call");
 		return NULL;
 	}
@@ -227,7 +227,7 @@ struct rpc_pdu *rpc_nfs3_access_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/ACCESS call");
 		return NULL;
 	}
@@ -545,7 +545,7 @@ rpc_nfs3_setattr_task(struct rpc_context *rpc, rpc_cb cb, SETATTR3args *args,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/SETATTR call");
 		return NULL;
 	}
@@ -570,7 +570,7 @@ struct rpc_pdu *rpc_nfs3_mkdir_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/MKDIR call");
 		return NULL;
 	}
@@ -596,7 +596,7 @@ struct rpc_pdu *rpc_nfs3_rmdir_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/RMDIR call");
 		return NULL;
 	}
@@ -621,7 +621,7 @@ struct rpc_pdu *rpc_nfs3_create_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/CREATE call");
 		return NULL;
 	}
@@ -647,7 +647,7 @@ struct rpc_pdu *rpc_nfs3_mknod_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/MKNOD call");
 		return NULL;
 	}
@@ -673,7 +673,7 @@ struct rpc_pdu *rpc_nfs3_remove_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/REMOVE call");
 		return NULL;
 	}
@@ -699,7 +699,7 @@ struct rpc_pdu *rpc_nfs3_readdir_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/READDIR call");
 		return NULL;
 	}
@@ -725,7 +725,7 @@ struct rpc_pdu *rpc_nfs3_readdirplus_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/READDIRPLUS call");
 		return NULL;
 	}
@@ -751,7 +751,7 @@ struct rpc_pdu *rpc_nfs3_fsstat_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/FSSTAT call");
 		return NULL;
 	}
@@ -777,7 +777,7 @@ struct rpc_pdu *rpc_nfs3_fsinfo_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/FSINFO call");
 		return NULL;
 	}
@@ -803,7 +803,7 @@ rpc_nfs3_readlink_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/READLINK call");
 		return NULL;
 	}
@@ -828,7 +828,7 @@ struct rpc_pdu *rpc_nfs3_symlink_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/SYMLINK call");
 		return NULL;
 	}
@@ -854,7 +854,7 @@ struct rpc_pdu *rpc_nfs3_rename_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/RENAME call");
 		return NULL;
 	}
@@ -879,7 +879,7 @@ struct rpc_pdu *rpc_nfs3_link_task(struct rpc_context *rpc, rpc_cb cb,
 		return NULL;
 	}
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/LINK call");
 		return NULL;
 	}


### PR DESCRIPTION
This is to avoid huge number of WRITE (and READ) PDUs to hijack a connection causing commands like ls/stat/find/chmod to appear to hang for a long time, since WRITEs can take really long to be sent out due to TCP window getting full (if server is unable to process them fast enough).

POSIX has compliance requirement only for completed requests. Since we are only reordering ongoing requests (not yet completed) it should not cause any violation. Moreover I cannot think of any application which will depend on any ordering guarantees of parallel requests.

Let's monitor it and if it causes any issuesm revisit on a case-by-case basic.