### PR TITLE
Added explicit APIs for adding pdus to low priority and high priority…

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -133,9 +133,13 @@ struct rpc_fragment {
 
 /*
  * Queue is singly-linked but we hold on to the tail
+ * Using tailp this can be used to queue high and low priority pdus where high
+ * priority pdus are at the head of the queue while low priority pdus are
+ * queued behind the high priority pdus. tailp is the tail of high priority
+ * pdus, after which the low priority pdus start.
  */
 struct rpc_queue {
-	struct rpc_pdu *head, *tail;
+	struct rpc_pdu *head, *tail, *tailp;
 };
 
 #define DEFAULT_HASHES 4
@@ -473,6 +477,10 @@ struct rpc_pdu {
         uint64_t removed_from_waitpdu_at_time;
         uint32_t in_waitpdu;
 #endif
+        /*
+         * Is it a high-prio pdu, added by rpc_add_to_outqueue_highp()?
+         */
+        bool_t is_high_prio;
 
 	struct rpc_data outdata;
 
@@ -615,7 +623,9 @@ struct rpc_pdu {
 
 void rpc_reset_queue(struct rpc_queue *q);
 void rpc_enqueue(struct rpc_queue *q, struct rpc_pdu *pdu);
-void rpc_add_to_outqueue(struct rpc_context *rpc, struct rpc_pdu *pdu);
+void rpc_add_to_outqueue_head(struct rpc_context *rpc, struct rpc_pdu *pdu);
+void rpc_add_to_outqueue_highp(struct rpc_context *rpc, struct rpc_pdu *pdu);
+void rpc_add_to_outqueue_lowp(struct rpc_context *rpc, struct rpc_pdu *pdu);
 void rpc_return_to_outqueue(struct rpc_context *rpc, struct rpc_pdu *pdu);
 int rpc_remove_pdu_from_queue(struct rpc_queue *q, struct rpc_pdu *remove_pdu);
 unsigned int rpc_hash_xid(struct rpc_context *rpc, uint32_t xid);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -428,6 +428,13 @@ rpc_write_to_socket(struct rpc_context *rpc)
                                 if (rpc->outqueue.head == NULL)
                                         rpc->outqueue.tail = NULL;
 
+                                /*
+                                 * Last high priority pdu dequeued, no more
+                                 * high priority pdus in outqueue.
+                                 */
+                                if (rpc->outqueue.tailp == pdu)
+                                        rpc->outqueue.tailp = NULL;
+
                                 assert(rpc->stats.outqueue_len > 0);
                                 rpc->stats.outqueue_len--;
 

--- a/nfs/nfs.c
+++ b/nfs/nfs.c
@@ -335,7 +335,14 @@ rpc_nfs3_readv_task(struct rpc_context *rpc, rpc_cb cb,
 
         pdu->requested_read_count = pdu->in.remaining_size;
 
-	if (rpc_queue_pdu(rpc, pdu) != 0) {
+        /*
+         * Add read requests to high priority queue so that they can be
+         * dispatched ahead of writes which can be large requests and too
+         * many writes queued can unnecessarily delay reads. By dispatching
+         * reads faster we can have them executed on the server and save
+         * undue delays.
+         */
+        if (rpc_queue_pdu2(rpc, pdu, 1 /* high_prio */) != 0) {
 		rpc_set_error(rpc, "Out of memory. Failed to queue pdu for NFS3/READ call");
 		return NULL;
 	}


### PR DESCRIPTION
… outqueue.

We add one more variable tailp to rpc_queue. This tracks the last high priority pdu, and allows us to maintain high priority and low priority pdus in the single outqueue, while maintaining order between pdus of the same priority. All requests except WRITEs are treated as high priority as they don't take much space in the socket queue and can be dispatched w/o much delay. Dispatching them fast lets them get processed at the server and overall we save time and also results in better user experience. Imagine queueing READ requests behind WRITEs and READs getting delayed as WRITEs cannot be sent due to server's TCP window filling up. OTOH if we send the READs with priority they can get serviced on the server in the time when WRITEs are still waiting to be sent, thus we can overall improve the number of reqs we can server per unit time.