### PR TITLE
Define multithreading_enabled as atomic_int type if HAVE_STDATOMIC_H …

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -313,10 +313,12 @@ struct rpc_context {
 	uint32_t max_waitpdu_len;
 
 #ifdef HAVE_MULTITHREADING
-        int multithreading_enabled;
         libnfs_mutex_t rpc_mutex;
 #ifndef HAVE_STDATOMIC_H
+        int multithreading_enabled;
         libnfs_mutex_t atomic_int_mutex;
+#else
+        atomic_int multithreading_enabled;
 #endif /* HAVE_STDATOMIC_H */
 #endif /* HAVE_MULTITHREADING */
 


### PR DESCRIPTION
…is defined

ON platforms that support atomic_int type (which is what we care about), define multithreading_enabled as atomic.
This prevents a TSAN warning in nfs_mt_service_thread()/nfs_mt_service_thread_start_ss() where a thread sets multithreading_enabled while main thread waits for it to be set.