### PR TITLE
Personal/linuxsmiths/use eventfd for notifying pollout

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -277,6 +277,7 @@ struct rpc_context {
 	uint32_t magic;
 	int fd;
 	int old_fd;
+	int evfd;
 	int is_connected;
 	int is_nonblocking;
 
@@ -312,12 +313,12 @@ struct rpc_context {
 	uint32_t waitpdu_len;
 	uint32_t max_waitpdu_len;
 
-#ifdef HAVE_MULTITHREADING
         /*
          * Linux thread id returned by gettid().
          * Used for logging.
          */
         pid_t tid;
+#ifdef HAVE_MULTITHREADING
         libnfs_mutex_t rpc_mutex;
 #ifndef HAVE_STDATOMIC_H
         int multithreading_enabled;

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -182,6 +182,7 @@ EXTERN void rpc_set_auth(struct rpc_context *rpc, struct AUTH *auth);
  * your event system and passing revents as 0.
  */
 EXTERN int rpc_get_fd(struct rpc_context *rpc);
+EXTERN int rpc_get_evfd(struct rpc_context *rpc);
 EXTERN int rpc_which_events(struct rpc_context *rpc);
 EXTERN int rpc_service(struct rpc_context *rpc, int revents);
 

--- a/include/nfsc/libnfs.h
+++ b/include/nfsc/libnfs.h
@@ -125,6 +125,7 @@ struct utimbuf {
  */
 EXTERN int nfs_get_tid(struct nfs_context *nfs);
 EXTERN int nfs_get_fd(struct nfs_context *nfs);
+EXTERN int nfs_get_evfd(struct nfs_context *nfs);
 EXTERN int nfs_which_events(struct nfs_context *nfs);
 EXTERN int nfs_service(struct nfs_context *nfs, int revents);
 

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -207,6 +207,12 @@ nfs_get_fd(struct nfs_context *nfs)
 }
 
 int
+nfs_get_evfd(struct nfs_context *nfs)
+{
+       return rpc_get_evfd(nfs->rpc);
+}
+
+int
 nfs_queue_length(struct nfs_context *nfs)
 {
 	return rpc_queue_length(nfs->rpc);

--- a/lib/multithreading.c
+++ b/lib/multithreading.c
@@ -151,7 +151,7 @@ void nfs_mt_service_thread_stop(struct nfs_context *nfs)
 
 	/* Signal the service thread to stop */
         nfs->rpc->multithreading_enabled = 0;
-	evbytes = write(rpc_get_evfd(rpc), &evwrite, sizeof(evwrite));
+	evbytes = write(rpc_get_evfd(nfs->rpc), &evwrite, sizeof(evwrite));
 	assert(evbytes == 8);
 	pthread_join(nfs->nfsi->service_thread, NULL);
 }

--- a/lib/multithreading.c
+++ b/lib/multithreading.c
@@ -146,8 +146,14 @@ int nfs_mt_service_thread_start_ss(struct nfs_context *nfs, size_t stack_bytes)
 
 void nfs_mt_service_thread_stop(struct nfs_context *nfs)
 {
+	uint64_t evwrite = 1;
+	[[maybe_unused]] ssize_t evbytes;
+
+	/* Signal the service thread to stop */
         nfs->rpc->multithreading_enabled = 0;
-        pthread_join(nfs->nfsi->service_thread, NULL);
+	evbytes = write(rpc_get_evfd(rpc), &evwrite, sizeof(evwrite));
+	assert(evbytes == 8);
+	pthread_join(nfs->nfsi->service_thread, NULL);
 }
         
 /*

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -257,6 +257,12 @@ rpc_get_fd(struct rpc_context *rpc)
 	return rpc->fd;
 }
 
+int
+rpc_get_evfd(struct rpc_context *rpc)
+{
+        return rpc->evfd;
+}
+
 /*
  * Does rpc->outqueue have one or more PDUs waiting to be sent out.
  */


### PR DESCRIPTION
Currently we depend on poll timeout, but that has a problem. If we make it too small it starts consuming CPU when not doing anything and too large might cause delays in processing outgoing PDUs.