### PR TITLE
Avoid loop in rpc_queue_length() by reading from stats.outqueue_len i…

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -2266,12 +2266,17 @@ rpc_queue_length(struct rpc_context *rpc)
                 nfs_mt_mutex_lock(&rpc->rpc_mutex);
         }
 #endif /* HAVE_MULTITHREADING */
+
+#ifdef ENABLE_PARANOID
 	for(pdu = rpc->outqueue.head; pdu; pdu = pdu->next) {
 		i++;
 	}
         assert(rpc->stats.outqueue_len == i);
-
+#else
+        i = rpc->stats.outqueue_len;
+#endif
 	i += rpc->waitpdu_len;
+
 #ifdef HAVE_MULTITHREADING
         if (rpc->multithreading_enabled) {
                 nfs_mt_mutex_unlock(&rpc->rpc_mutex);


### PR DESCRIPTION
…nstead of looping

Looping is left for paranoid build.