### PR TITLE
Allow user to find out whether a PDU that completed was retransmitted.

### DIFF
--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -614,6 +614,22 @@ struct rpc_pdu {
          */
         bool_t is_head_prio;
 
+        /*
+         * Was this PDU retransmitted?
+         * libnfs lets its users know if a PDU that completed, was retransmitted
+         * or was it only sent to the server once. Users can use this info to
+         * do useful things, f.e., one of the thing they can do is work around
+         * the weakly consistent nature of NFS by treating an NFS3ERR_NOENT
+         * returned by a REMOVE/RMDIR call as NFS3_OK since it may have been
+         * deleted the first time it was sent and the subsequent retransmit
+         * may have gone to another node (which doesn't share the DRC cache)
+         * and hence it failed it with NFS3ERR_NOENT.
+         * Note that most applications will handle an unlink() call succeeding
+         * for a non-existent file better than unlink() call failing with
+         * NOENT for a file that was actually present.
+         */
+        bool_t is_retransmitted;
+
         struct rpc_data outdata;
 
         /* For sending/receiving

--- a/include/nfsc/libnfs-raw.h
+++ b/include/nfsc/libnfs-raw.h
@@ -202,6 +202,17 @@ EXTERN int rpc_service(struct rpc_context *rpc, int revents);
 EXTERN struct rpc_pdu *rpc_get_pdu(struct rpc_context *rpc);
 
 /*
+ * Was this PDU retransmitted? i.e., did we send it to the server more than
+ * once? User can use this info to relax some errors, f.e., a REMOVE request
+ * that fails with NFS3ERR_NOENT can be treated as success if it was a
+ * retransmited request.
+ * Note that most applications will handle an unlink() call succeeding for a
+ * non-existent file better than unlink() call failing with NOENT for a file
+ * that was actually present.
+ */
+EXTERN bool_t rpc_pdu_is_retransmitted(struct rpc_pdu *pdu);
+
+/*
  * Get the size in bytes of the RPC request that libnfs will send out for
  * this PDU. The size includes the RPC header, the NFS header and any data
  * bytes sent (only WRITE RPC request will send data bytes).

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -268,6 +268,7 @@ void rpc_return_to_outqueue(struct rpc_context *rpc, struct rpc_pdu *pdu)
          * it out will entail a retransmit.
          */
         INC_STATS(rpc, num_retransmitted);
+        pdu->is_retransmitted = 1;
 
         /*
          * Reset output and input cursors as we have to re-send the whole pdu
@@ -618,6 +619,9 @@ struct rpc_pdu *rpc_allocate_pdu2(struct rpc_context *rpc, int program, int vers
         /* Add an iovector for the header */
         rpc_add_iovector(rpc, &pdu->out, &pdu->outdata.data[4],
                          zdr_getpos(&pdu->zdr), NULL);
+
+        /* Freshly allocated PDU cannot be retransmitted */
+        assert(!pdu->is_retransmitted);
 
 	return pdu;
  failed:
@@ -1419,6 +1423,11 @@ struct rpc_pdu *rpc_find_pdu(struct rpc_context *rpc, uint32_t xid)
 #endif /* HAVE_MULTITHREADING */
 
         return pdu;
+}
+
+bool_t rpc_pdu_is_retransmitted(struct rpc_pdu *pdu)
+{
+        return pdu->is_retransmitted;
 }
 
 uint32_t rpc_pdu_get_req_size(struct rpc_pdu *pdu)


### PR DESCRIPTION
Was the PDU retransmitted? i.e., did we send it to the server more than once? User can use this info to relax some errors, f.e., a REMOVE request that fails with NFS3ERR_NOENT can be treated as success if it was a retransmited request.
Note that most applications will handle an unlink() call succeeding for a non-existent file better than unlink() call failing with NOENT for a file that was actually present.