### PR TITLE
Remove GnuTLS dependency; always send AzAuthNone over non-TLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,34 +67,10 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   add_definitions("-D_U_=__attribute__((unused))")
   #
-  # Currently RPC-with-TLS support is only available on Linux since it depends on kTLS support
-  # on Linux.
+  # RPC-with-TLS support (and its GnuTLS dependency) has been removed. Only the
+  # non-TLS transport (xprtsec=none) is supported. This avoids depending on
+  # gnutls which is not an allowed package on some distros (e.g. Azure Linux).
   #
-  # TODO: BSD also has kTLS support, but that will need separate validation.
-  #
-  find_package(GnuTLS "3.4.6")
-  if(GNUTLS_FOUND)
-    #
-    # Make sure the two most important header files are present before we enable TLS support,
-    # to avoid running into issues later during build. GnuTLS package found but gnutls/gnutls.h
-    # not found is a serious issue while if linux/tls.h is not found it would likely mean that
-    # user is using a kernel not supporting kTLS so we simply don't turn on TLS support.
-    #
-    check_include_file("gnutls/gnutls.h" HAVE_GNUTLS_H)
-    if(NOT HAVE_GNUTLS_H EQUAL "1")
-      message(FATAL_ERROR "GnuTLS found but gnutls/gnutls.h not found, GNUTLS_INCLUDE_DIR is ${GNUTLS_INCLUDE_DIR}")
-    endif()
-
-    check_include_file("linux/tls.h" HAVE_LINUX_TLS_H)
-    if(NOT HAVE_LINUX_TLS_H EQUAL "1")
-      message(STATUS "GnuTLS found but linux/tls.h not found, likely a kernel w/o kTLS support, can't enable TLS support")
-    else()
-      message(STATUS "Using ${GNUTLS_LIBRARIES}")
-      add_definitions(-DHAVE_TLS)
-      list(APPEND SYSTEM_LIBRARIES ${GNUTLS_LIBRARIES})
-      add_subdirectory(tls)
-    endif()
-  endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
   add_definitions("-D_U_=" -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   list(APPEND SYSTEM_LIBRARIES ws2_32)

--- a/include/libnfs-private.h
+++ b/include/libnfs-private.h
@@ -518,6 +518,7 @@ struct rpc_context {
 
 	/* Context used for performing TLS handshake with the server */
 	struct tls_context tls_context;
+#endif /* HAVE_TLS */
 
         /*
          * Do we need to perform auth on connect/reconnect?
@@ -532,7 +533,6 @@ struct rpc_context {
          */
         bool_t use_azauth;
         struct auth_context auth_context;
-#endif /* HAVE_TLS */
 
 #ifdef HAVE_LIBKRB5
         const char *username;

--- a/lib/libnfs.c
+++ b/lib/libnfs.c
@@ -356,19 +356,22 @@ nfs_set_context_args(struct nfs_context *nfs, const char *arg, const char *val)
 		} else {
 			nfs_set_readdir_max_buffer_size(nfs, atoi(val), atoi(val));
 		}
-#ifdef HAVE_TLS
 	} else if (nfs->rpc && !strcmp(arg, "xprtsec")) {
 		if (!strcmp(val, "none")) {
+#ifdef HAVE_TLS
 			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_NONE);
+#endif
+			/* Non-TLS transport, nothing to configure. */
+#ifdef HAVE_TLS
 		} else if (!strcmp(val, "tls")) {
 			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_TLS);
 		} else  if (!strcmp(val, "mtls")) {
 			nfs_set_xprtsecurity(nfs, RPC_XPRTSEC_MTLS);
+#endif /* HAVE_TLS */
 		} else {
 			nfs_set_error(nfs, "Unknown/unsupported xprtsec type : %s", val);
 			return -1;
 		}
-#endif /* HAVE_TLS */
 #ifdef HAVE_LIBKRB5
 	} else if (nfs->rpc && !strcmp(arg, "sec")) {
                 /*
@@ -600,9 +603,11 @@ int nfs_set_auth_context(struct nfs_context *nfs,
         assert(client_id);
 
         if (nfs->rpc) {
-#ifndef ENABLE_INSECURE_AUTH_FOR_DEVTEST
+#if defined(HAVE_TLS) && !defined(ENABLE_INSECURE_AUTH_FOR_DEVTEST)
                 /*
                  * If not devtest, don't allow auth unless transport is secure.
+                 * Note: When TLS support is not compiled in (no gnutls), only
+                 * the non-TLS transport exists, so auth is always allowed.
                  */
                 if (nfs->rpc->wanted_xprtsec == RPC_XPRTSEC_NONE) {
                         RPC_LOG(nfs->rpc, 1, "Cannot enable auth for xprtsec=none");
@@ -886,13 +891,6 @@ void free_azauth_cb_data(struct azauth_cb_data *data)
         free(data);
 }
 
-#ifdef HAVE_TLS
-void free_tls_cb_data(struct tls_cb_data *data)
-{
-        assert(data->magic == TLS_CB_DATA_MAGIC);
-        free(data);
-}
-
 /*
  * Callback function called when we get a response for an AZAUTH RPC from the
  * server.
@@ -914,7 +912,18 @@ rpc_connect_program_4_2_cb(struct rpc_context *rpc, int status,
         assert(rpc->auth_context.is_authorized == FALSE);
 
         if (status != RPC_STATUS_SUCCESS) {
-                RPC_LOG(rpc, 1, "AZAUTH RPC failure, status = %d", status);
+                /*
+                 * The most common reason for the AZAUTH RPC to fail (either a
+                 * timeout with no response, or the server rejecting the RPC) is
+                 * that the server does not have AzAuth (AzAuthNone) enabled or
+                 * setup for this account. Call this out clearly so it's easy to
+                 * tell apart from a generic network failure.
+                 */
+                RPC_LOG(rpc, 1, "AZAUTH RPC failed (status=%d): the server "
+                                "rejected or did not respond to the AZAUTH "
+                                "(AzAuthNone) RPC. This usually means AzAuth "
+                                "(AzAuthNone) is not enabled/setup on the server "
+                                "for this account.", status);
 
                 data->cb(rpc, status, command_data, data->private_data);
                 free_azauth_cb_data(data);
@@ -965,6 +974,13 @@ rpc_connect_program_4_2_cb(struct rpc_context *rpc, int status,
          */
         data->cb(rpc, RPC_STATUS_SUCCESS, NULL, data->private_data);
         free_azauth_cb_data(data);
+}
+
+#ifdef HAVE_TLS
+void free_tls_cb_data(struct tls_cb_data *data)
+{
+        assert(data->magic == TLS_CB_DATA_MAGIC);
+        free(data);
 }
 
 /*
@@ -1169,13 +1185,14 @@ rpc_connect_program_4_cb(struct rpc_context *rpc, int status,
 	} else
 #endif /* HAVE_TLS */
 
-#ifdef ENABLE_INSECURE_AUTH_FOR_DEVTEST
         if (rpc->use_azauth) {
                 /*
-                 * Insecure connection, if azauth is enabled perform auth.
-                 *
-                 * Note: THIS WOULD SEND THE TOKEN OVER AN INSECURE CONNECTION
-                 *       AND MUST ONLY BE USED IN DEVTEST ON TRUSTED NETWORKS.
+                 * TLS support has been removed, so AZAUTH is always sent over a
+                 * non-TLS connection. When the context has azauth enabled we
+                 * send the AZAUTH RPC (AzAuthNone/AzAuthAAD) as the very first
+                 * RPC on the connection. If the server does not have azauth
+                 * enabled it will not respond and the AZAUTH RPC will time out;
+                 * rpc_connect_program_4_2_cb() reports that case clearly.
                  */
                 if (rpc_perform_azauth(rpc, rpc_connect_program_5_cb, data) == NULL) {
                         data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);
@@ -1183,7 +1200,6 @@ rpc_connect_program_4_cb(struct rpc_context *rpc, int status,
                         return;
                 }
         } else
-#endif
         if (rpc_null_task(rpc, data->program, data->version,
                           rpc_connect_program_5_cb, data) == NULL) {
                 data->cb(rpc, RPC_STATUS_ERROR, command_data, data->private_data);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -1951,22 +1951,21 @@ rpc_disconnect(struct rpc_context *rpc, const char *error)
 	return 0;
 }
 
-#ifdef HAVE_TLS
-
 /*
- * During TCP reconnection, for secure transport, we need to re-perform auth.
+ * During TCP reconnection we need to re-perform auth (AZAUTH) before any
+ * other RPC can be sent on the reconnected connection.
  * This is the callback function called when auth completes.
 */
 static void
 reconnect_cb_azauth(struct rpc_context *rpc, int status,
                     void *command_data, void *private_data)
 {
-        /* reconnect_cb_tls() passes NULL as private_data */
+        /* reconnect_cb()/reconnect_cb_tls() pass NULL as private_data */
         assert(private_data == NULL);
 
         assert(rpc->magic == RPC_CONTEXT_MAGIC);
 
-        /* Must be called only for TLS transport */
+        /* Must be called only when azauth is enabled */
         assert(rpc->use_azauth);
 
         /*
@@ -1988,6 +1987,8 @@ reconnect_cb_azauth(struct rpc_context *rpc, int status,
 
         RPC_LOG(rpc, 2, "reconnect_cb_azauth: AzAuth completed successfully!");
 }
+
+#ifdef HAVE_TLS
 
 /*
  * During TCP reconnection (either server or client closes connection) for secure
@@ -2092,18 +2093,15 @@ reconnect_cb(struct rpc_context *rpc, int status, void *data,
 			rpc_reconnect_requeue(rpc);
 			return;
 		}
-	}
+	} else
 #endif /* HAVE_TLS */
-
-#ifdef ENABLE_INSECURE_AUTH_FOR_DEVTEST
-        else if (rpc->use_azauth) {
+        if (rpc->use_azauth) {
                 /*
-                 * Insecure connection, if azauth is enabled perform auth.
-                 *
-                 * Note: THIS WOULD SEND THE TOKEN OVER AN INSECURE CONNECTION
-                 *       AND MUST ONLY BE USED IN DEVTEST ON TRUSTED NETWORKS.
+                 * TLS support has been removed, so AZAUTH is sent over the
+                 * non-TLS connection on reconnect too. This re-authorizes the
+                 * reconnected connection before any other RPC is sent on it.
                  */
-                RPC_LOG(rpc, 2, "reconnect_cb: sending insecure AZAUTH RPC");
+                RPC_LOG(rpc, 2, "reconnect_cb: sending AZAUTH RPC");
 
                 if (rpc_perform_azauth(rpc, reconnect_cb_azauth, NULL) == NULL) {
                         RPC_LOG(rpc, 1, "reconnect_cb: rpc_perform_azauth() failed, "
@@ -2116,7 +2114,6 @@ reconnect_cb(struct rpc_context *rpc, int status, void *data,
                         rpc_reconnect_requeue(rpc);
                 }
         }
-#endif
 }
 
 /* Disconnect but do not error all PDUs, just move pdus in-flight back to the


### PR DESCRIPTION
## Summary
Removes the GnuTLS / RPC-with-TLS dependency so builds are not blocked on distros where gnutls is not an allowed package (e.g. Azure Linux). Only the non-TLS transport (`xprtsec=none`) is supported now, and AZAUTH (AzAuthNone) is always performed over the non-TLS connection.

## Changes
- **CMakeLists.txt**: drop `find_package(GnuTLS)` / `HAVE_TLS` and the `tls` subdirectory, so gnutls is never required or linked.
- **include/libnfs-private.h**: move `use_azauth` / `auth_context` out of the `HAVE_TLS` guard (AZAUTH is a non-TLS feature).
- **lib/libnfs.c**:
  - move the AZAUTH response callback out of the `HAVE_TLS` guard;
  - accept `xprtsec=none` in the URL parser without TLS compiled in;
  - always perform AZAUTH (AzAuthNone) as the first RPC when azauth is enabled;
  - emit a clear diagnostic when the server rejects / does not respond to the AZAUTH RPC (usually means AzAuth is not enabled/setup on the server for the account).
- **lib/socket.c**: perform AZAUTH on reconnect over non-TLS, and move `reconnect_cb_azauth` out of the `HAVE_TLS` guard.

## Testing
- Builds cleanly with no gnutls linkage (`ldd` shows no gnutls/p11-kit/nettle/etc).
- AzAuth-enabled account: AzAuthNone accepted, proceeds to MOUNT (server responds).
- Non-AzAuth account: AZAUTH fails fast with the clear diagnostic message.